### PR TITLE
Uniformisation des items.json.jb

### DIFF
--- a/app/views/api/v1/items/index.json.jb
+++ b/app/views/api/v1/items/index.json.jb
@@ -6,16 +6,19 @@ def retrieve_info
             img_url: item.img_url,
             ressource_type: item.ressource_type,
             unit_price_info: {
+                price_list: [],
                 median_price: item.unit_price_info&.dig("median_price") || 0,
                 capital_gain: item.unit_price_info&.dig("capital_gain").ceil || 0,
                 current_price: item.unit_price_info["price_list"].last&.dig("price") || 0,
             },
             tenth_price_info: {
+                price_list: [],
                 median_price: item.tenth_price_info&.dig("median_price") || 0,
                 capital_gain: item.tenth_price_info&.dig("capital_gain").ceil || 0,
                 current_price: item.tenth_price_info["price_list"].last&.dig("price") || 0,
             },
             hundred_price_info: {
+                price_list: [],
                 median_price: item.hundred_price_info&.dig("median_price") || 0,
                 capital_gain: item.hundred_price_info&.dig("capital_gain").ceil || 0,
                 current_price: item.hundred_price_info["price_list"].last&.dig("price") || 0,

--- a/app/views/api/v1/items/show.json.jb
+++ b/app/views/api/v1/items/show.json.jb
@@ -2,8 +2,25 @@ json = {
     item: {
         id: @item.id,
         name: @item.name,
-        unit_price_info: @item.unit_price_info["price_list"],
-        tenth_price_info: @item.tenth_price_info["price_list"],
-        hundred_price_info: @item.hundred_price_info["price_list"]
+        img_url: @item.img_url,
+        ressource_type: @item.ressource_type,
+        unit_price_info: {
+            price_list: @item.unit_price_info&.dig("price_list") || [],
+            median_price: @item.unit_price_info&.dig("median_price") || 0,
+            capital_gain: @item.unit_price_info&.dig("capital_gain").ceil || 0,
+            current_price: @item.unit_price_info["price_list"].last&.dig("price") || 0,
+        },
+        tenth_price_info: {
+            price_list: @item.tenth_price_info&.dig("price_list") || [],
+            median_price: @item.tenth_price_info&.dig("median_price") || 0,
+            capital_gain: @item.tenth_price_info&.dig("capital_gain").ceil || 0,
+            current_price: @item.tenth_price_info["price_list"].last&.dig("price") || 0,
+        },
+        hundred_price_info: {
+            price_list: @item.hundred_price_info&.dig("price_list") || [],
+            median_price: @item.hundred_price_info&.dig("median_price") || 0,
+            capital_gain: @item.hundred_price_info&.dig("capital_gain").ceil || 0,
+            current_price: @item.hundred_price_info["price_list"].last&.dig("price") || 0,
+        },
     }
 }


### PR DESCRIPTION
Rendre les outputs plus facilement traitable en front via la réponse json. Pour n'utiliser qu'un seul .fromJson